### PR TITLE
fixed "Failed to load" on cdn imported resources

### DIFF
--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>Vaadin Grid with paged REST datasource</title>
-  <script src="https://cdn.vaadin.com/vaadin-elements/0.3.0-beta12/webcomponentsjs/webcomponents-lite.min.js"></script>
-  <link href="https://cdn.vaadin.com/vaadin-elements/0.3.0-beta12/vaadin-elements/vaadin-elements.html" rel="import">
+  <script src="https://cdn.vaadin.com/vaadin-elements/1.5.0/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <link href='https://cdn.vaadin.com/vaadin-elements/1.5.0/vaadin-grid/vaadin-grid.html' rel='import'>
   <script src="Promise.min.js"></script>
   <script src="main.js"></script>
 


### PR DESCRIPTION

```0.3.0-beta12``` no more available on CND  cause ```404``` visible only on js-console for missing resources; as a consequence the grid cannot start. 

proposed patch: ( tested on 20171105 with higher stable working release of components )
``` patch 
From bd9b152085b0a0b6a71eb42b88d01da184e60a0e Mon Sep 17 00:00:00 2001
From: Franco Rondini 
Date: Sun, 5 Nov 2017 17:06:29 +0100
Subject: [PATCH] fixed "Failed to load" on cdn imported resources

---
 src/main/resources/public/index.html | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

diff --git a/src/main/resources/public/index.html b/src/main/resources/public/index.html
index 3ada49f..94bc60d 100644
--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>Vaadin Grid with paged REST datasource</title>
-  <script src="https://cdn.vaadin.com/vaadin-elements/0.3.0-beta12/webcomponentsjs/webcomponents-lite.min.js"></script>
-  <link href="https://cdn.vaadin.com/vaadin-elements/0.3.0-beta12/vaadin-elements/vaadin-elements.html" rel="import">
+  <script src="https://cdn.vaadin.com/vaadin-elements/1.5.0/webcomponentsjs/webcomponents-lite.min.js"></script>
+  <link href='https://cdn.vaadin.com/vaadin-elements/1.5.0/vaadin-grid/vaadin-grid.html' rel='import'>
   <script src="Promise.min.js"></script>
   <script src="main.js"></script>
 
-- 
2.13.5 (Apple Git-94)
```
